### PR TITLE
Use instead of restoring side table for Loop

### DIFF
--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -64,10 +64,6 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(result)
     }
 
-    pub fn parse_bytes_reversely(&mut self, delta: i32) -> MResult<&'m [u8], M> {
-        unimplemented!()
-    }
-
     pub fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
         Ok(Self::internal_new(self.parse_bytes(len)?))
     }
@@ -565,15 +561,6 @@ impl<'m, M: Mode> Parser<'m, M> {
                 Instr::End => depth -= 1,
                 _ => (),
             }
-        }
-        Ok(())
-    }
-
-    pub fn skip_to(&mut self, delta: i32) -> MResult<(), M> {
-        if delta >= 0 {
-            self.parse_bytes(delta as usize)?;
-        } else {
-            self.parse_bytes_reversely(delta)?;
         }
         Ok(())
     }

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -64,6 +64,10 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(result)
     }
 
+    pub fn parse_bytes_reversely(&mut self, delta: i32) -> MResult<&'m [u8], M> {
+        unimplemented!()
+    }
+
     pub fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
         Ok(Self::internal_new(self.parse_bytes(len)?))
     }
@@ -561,6 +565,15 @@ impl<'m, M: Mode> Parser<'m, M> {
                 Instr::End => depth -= 1,
                 _ => (),
             }
+        }
+        Ok(())
+    }
+
+    pub fn skip_to(&mut self, delta: i32) -> MResult<(), M> {
+        if delta >= 0 {
+            self.parse_bytes(delta as usize)?;
+        } else {
+            self.parse_bytes_reversely(delta)?;
         }
         Ok(())
     }


### PR DESCRIPTION
On my Linux Docker container:

1. 

CoreMark results of this PR: 37.991516 (in 18.695s), 36.7287 (in 19.258s)

CoreMark results of https://github.com/google/wasefire/pull/690: 37.101162 (in 19.133s), 37.39716 (in 18.996s)

Look very similar. Not sure about `nordic`.

2. 

CoreMark results of `main`: 28.791477 (in 18.09s), 28.814291 (in 17.734s)

So there does seem some minor performance improvement with `delta_ip` and `delta_stp`.

https://github.com/google/wasefire/issues/46
